### PR TITLE
Add rudimentary support for working with the Syncthing API

### DIFF
--- a/emacs-conflict-test.el
+++ b/emacs-conflict-test.el
@@ -32,6 +32,28 @@
            (emacs-conflict--get-normal-filename "tests/conflicts/one.sync-conflict-AABBCC.el")
            "tests/conflicts/one.el")))
 
+(ert-deftest emacs-conflict-syncthing-conflict-file ()
+  "Tests the inverse of the test above."
+  (let ((emacs-conflict-syncthing-conflicts-cache
+         '("tests/conflicts/one.sync-conflict-AABBCC.el")))
+    (should (equal
+             (emacs-conflict-syncthing-conflict-file "tests/conflicts/one.el")
+             "tests/conflicts/one.sync-conflict-AABBCC.el"))))
+
+(ert-deftest emacs-conflict--syncthing-require-version ()
+  "Tests that the version checker works accordingly.
+
+It's expected to error when the version is too low, and return nil otherwise."
+  ;; Working current version
+  (flet ((shell-command-to-string (x) "syncthing v1.12.0"))
+    (should (null (emacs-conflict--syncthing-require-version "1.12.0"))))
+  ;; Future version also works
+  (flet ((shell-command-to-string (x) "syncthing v2.12.0"))
+    (should (null (emacs-conflict--syncthing-require-version "1.12.0"))))
+  ;; Error out when we're too low
+  (flet ((shell-command-to-string (x) "syncthing v1.0.0"))
+    (should-error (emacs-conflict--syncthing-require-version "1.12.0"))))
+
 (provide 'emacs-conflict-test)
 
 ;;; emacs-conflict-test.el ends here

--- a/emacs-conflict.el
+++ b/emacs-conflict.el
@@ -4,7 +4,8 @@
 
 ;; Author: Pierre Penninckx <ibizapeanut@gmail.com>
 ;; URL: https://github.com/ibizaman/emacs-conflicts
-;; Version: 0.1.0
+;; Version: 0.2.0
+;; Package-Requires: ((emacs "25.0") (dash "2.11.0"))
 
 ;; This file is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published
@@ -47,20 +48,176 @@
 (require 'dired)
 (require 'dired-aux)
 (require 'ediff)
+(require 'url)
+(require 'cl)
+(require 'dash)
+
+(defgroup emacs-conflict nil
+  "Handle conflicts when syncing files"
+  :group 'external
+  :prefix "emacs-conflict-")
+
+(defcustom emacs-conflict-syncthing-url "http://localhost:8384/rest/"
+  "The base URL for talking to Syncthing.
+
+This should include the \"/rest/\" part."
+  :type 'string)
+
+(defcustom emacs-conflict-syncthing-api-keys nil
+  "Lookup for the API key used i making requests to Syncthing.
+
+Stored as an alist with the hostname as key and the API key as value. The alist
+approach was chosen since it's not uncommon to use Syncthing to sync dotfiles
+across multiple hosts. This avoids conflict in having a single key available for
+all Syncthing instances.
+
+The API key be obtained in the GUI in the Settings window."
+  :type '(alist :key-type string :value-type string))
+
+(defvar emacs-conflict-syncthing-conflict-marker ".sync-conflict"
+  "The string used to denote that a file is a conflict file.")
+
+(defvar emacs-conflict-syncthing-refresh-cache nil
+  "Denotes if we should query Syncthing or use the cache.
+
+Should only be set via `let' whenever we want to explcitly update the cache.
+Avoid `setq' on this otherwise.")
+
+(defun emacs-conflict--syncthing-require-version (version-string)
+  "Check if VERSION-STRING is higher than the current installed version of Syncthing."
+  (let* ((current-string
+          ;; The substring removes the "v", since the emacs version- functions
+          ;; don't like those.
+          (substring
+           (second
+            (split-string (shell-command-to-string "syncthing -version") " "))
+           1))
+         (current (version-to-list current-string))
+         (check (version-to-list version-string)))
+    (i (version-list-< current check)
+      (user-error "This feature requires Syncthing version %s and %s is installed. Please upgrade Syncthing to use this feature."
+                  version-string
+                  current-string))))
+
+(defun emacs-conflict--get (url)
+  "Make a GET request to the Syncthing API.
+
+The object returned is the parsed JSON from the response."
+  (let* ((url (concat emacs-conflict-syncthing-url url))
+         (url-request-extra-headers (list (cons "X-API-key" (emacs-conflict-syncthing--api-key)))))
+    ;; TODO(thiderman): Maybe some error handling if a non-200 response is returned?
+    (with-current-buffer (url-retrieve-synchronously url)
+      (let* ((json-object-type 'plist)
+             (json-key-type 'symbol)
+             (json-array-type 'vector))
+        (goto-char (point-min))
+        (re-search-forward "^$")
+        (json-read)))))
+
+(defun emacs-conflict-syncthing--api-key ()
+  "Gets the API key for the current system, or requests it.
+
+If requested, it is saved and persisted into `customize'."
+  (let* ((key (alist-get (system-name) emacs-conflict-syncthing-api-keys)))
+    (unless key
+      (setq key (read-string "Syncthing API Key (obtain from Settings page in GUI): "))
+      (customize-save-variable
+       'emacs-conflict-syncthing-api-keys
+       (acons (system-name) key emacs-conflict-syncthing-api-keys)))
+    key))
+
+(defun emacs-conflict-syncthing-roots ()
+  "Lists all directories that are synced with Syncthing."
+  ;; The /config/ endpoint was only made accessible via the API in version 1.12.
+  ;; There are other ways of getting the roots, but this is by far the simplest
+  ;; and most reliable one.
+  (emacs-conflict--syncthing-require-version "1.12.0")
+  (let* ((folders (plist-get (emacs-conflict--get "config") 'folders))
+         ;; We're using `expand-file-name' here since Syncthing has a tendency
+         ;; to sometimes use the ~ shorthand for $HOME and sometimes not.
+         (roots (-map (lambda (f)
+                        (expand-file-name (plist-get f 'path)))
+                      folders)))
+    (sort roots 'string-lessp)))
+
+(defvar emacs-conflict-syncthing-conflicts-cache nil
+  "Current conflict files in all syncthing folders.
+
+This cache is used since finding conflicts in large (>GB) Syncthing folders can
+be quite slow.")
+
+(defun emacs-conflict-syncthing-conflicts ()
+  "Gets all conflicts in Syncthing.
+
+The result is put into `emacs-conflict-syncthing-conflicts-cache'. This cache is
+  used unless empty or `emacs-conflict-syncthing-refresh-cache' is non-nil."
+  (if (or emacs-conflict-syncthing-refresh-cache
+          (not emacs-conflict-syncthing-conflicts-cache))
+      (progn
+        (message "Getting Syncthing conflicts...")
+        (setq emacs-conflict-syncthing-conflicts-cache
+              (-flatten
+               (-map
+                #'emacs-conflict--get-sync-conflicts
+                (emacs-conflict-syncthing-roots))))
+        (message "Conflict update complete.")))
+  emacs-conflict-syncthing-conflicts-cache)
+
+(defun emacs-conflict-syncthing-conflicts-refresh-cache ()
+  "Update the contents of the conflict cache.
+
+This always refreshes and returns `emacs-conflict-syncthing-conflicts-cache'."
+  (interactive)
+  (let ((emacs-conflict-syncthing-refresh-cache t))
+    (emacs-conflict-syncthing-conflicts)))
 
 
-(defun emacs-conflict-resolve-conflicts (directory)
-  "Resolve all conflicts under given DIRECTORY."
-  (interactive "D")
-  (let* ((all (emacs-conflict--get-sync-conflicts directory))
-         (chosen (emacs-conflict--pick-a-conflict all)))
-    (emacs-conflict--resolve-conflict chosen)))
+
+(defun emacs-conflict-syncthing-conflict-file (filename)
+  "Returns the conflict file for FILENAME if one is found in
+`emacs-conflict-syncthing-conflicts'."
+  ;; TODO(thiderman): Add support for finding multiple conflicts
+  (cl-find filename (emacs-conflict-syncthing-conflicts)
+           ;; Tests if the target file has the marker
+           :test (lambda (target conflict)
+                   (string-prefix-p
+                    (concat (file-name-sans-extension target) emacs-conflict-syncthing-conflict-marker)
+                    conflict))))
+
+(defun emacs-conflict-act (func &optional directory)
+  "Pick a conflict and call FUNC with it as only argument."
+  (let* ((conflicts (if directory
+                        (emacs-conflict--get-sync-conflicts directory)
+                      (emacs-conflict-syncthing-conflicts)))
+         (chosen (emacs-conflict--pick-a-conflict conflicts)))
+    (funcall func chosen)))
+
+(defun emacs-conflict-resolve-conflicts (&optional directory)
+  "Resolve all conflicts under given DIRECTORY.
+
+If no DIRECTORY is given, it defaults to all conflicts returned by
+  `emacs-conflict-syncthing-conflicts' rather than in a specific directory."
+  (interactive)
+  (emacs-conflict-act #'emacs-conflict--resolve-conflict directory))
+
+(defun emacs-conflict-remove-conflict (&optional directory)
+  "Remove a conflict file.
+
+If no DIRECTORY is given, it defaults to all conflicts returned by
+  `emacs-conflict-syncthing-conflicts' rather than in a specific directory."
+  (interactive)
+  (emacs-conflict-act #'emacs-conflict--remove-conflict directory))
 
 
 (defun emacs-conflict-show-conflicts-dired (directory)
-  "Open dired buffer at DIRECTORY showing all syncthing conflicts."
-  (interactive "D")
-  (find-name-dired directory "*.sync-conflict-*"))
+  "Open dired buffer at DIRECTORY showing all syncthing conflicts.
+
+If no directory is given, a prompt to select one from
+`emacs-conflict-syncthing-roots' is shown."
+  (interactive
+   ;; TODO(thiderman): Only show roots that have conflicts?
+   (list (completing-read "Syncthing root: " (emacs-conflict-syncthing-roots))))
+  (find-name-dired directory (format "*%s-*" emacs-conflict-syncthing-conflict-marker)))
 
 
 (defun emacs-conflict-resolve-conflict-dired (&optional arg)
@@ -76,28 +233,45 @@
     (emacs-conflict--resolve-ediff
      (list conflict normal)
      `(lambda ()
-        (when (y-or-n-p "Delete conflict file? ")
-          (kill-buffer (get-file-buffer ,conflict))
-          (delete-file ,conflict))))))
+        (emacs-conflict--remove-conflict ,conflict)))))
+
+(defun emacs-conflict--remove-conflict (conflict)
+  "Deletes the conflict file and its buffer, and removes it from the conflict cache."
+  (when (y-or-n-p (format "Delete conflict file %s? "
+                          (file-name-nondirectory conflict)))
+    ;; If there is no buffer, kill-buffer will be called with a nil argument,
+    ;; which means kill the current buffer - not what we want.
+    (if-let ((buf (get-file-buffer conflict)))
+        (kill-buffer buf))
+    (delete-file conflict)
+    (setq emacs-conflict-syncthing-conflicts-cache
+          (remove
+           conflict
+           emacs-conflict-syncthing-conflicts-cache))
+    t))
 
 
 (defun emacs-conflict--get-sync-conflicts (directory)
   "Return a list of all sync conflict files in a DIRECTORY."
-  (directory-files-recursively directory "\\.sync-conflict-"))
+  (directory-files-recursively directory
+                               (format "%s-" (regexp-quote emacs-conflict-syncthing-conflict-marker))))
 
 
-(defvar emacs-conflict--conflict-history
+(defvar emacs-conflict--conflict-history nil
   "Completion conflict history")
 
 (defun emacs-conflict--pick-a-conflict (conflicts)
-  "Let user choose the next conflict from CONFLICTS to investigate."
-  (completing-read "Choose the conflict to investigate: " conflicts
+  "Let user choose the next conflict from CONFLICTS."
+  (completing-read "Choose conflict: " conflicts
                    nil t nil emacs-conflict--conflict-history))
 
 
 (defun emacs-conflict--get-normal-filename (conflict)
-  "Get non-conflict filename matching the given CONFLICT."
-  (replace-regexp-in-string "\\.sync-conflict-.*\\(\\..*\\)$" "\\1" conflict))
+  "Get non-conflict filename matching the given CONFLICT.
+
+Tries to preserve the file extension."
+  (replace-regexp-in-string
+   (format "%s-.*\\(\\..*\\)$" (regexp-quote emacs-conflict-syncthing-conflict-marker)) "\\1" conflict))
 
 
 (defun emacs-conflict--resolve-ediff (&optional files quit-hook)
@@ -126,6 +300,14 @@ QUIT-HOOK, if given is called ."
                       (when quit-hook (funcall quit-hook))
                       (set-window-configuration wnd))))
       (error "No more than 2 files should be marked"))))
+
+
+(let ((map (define-prefix-command #'emacs-conflict-map)))
+  (define-key map "c" #'emacs-conflict-resolve-conflicts)
+  (define-key map "d" #'emacs-conflict-resolve-conflict-dired)
+  (define-key map "r" #'emacs-conflict-syncthing-conflicts-refresh-cache)
+  (define-key map "k" #'emacs-conflict-remove-conflict)
+  map)
 
 (provide 'emacs-conflict)
 ;;; emacs-conflict.el ends here

--- a/emacs-conflict.el
+++ b/emacs-conflict.el
@@ -94,7 +94,7 @@ Avoid `setq' on this otherwise.")
            1))
          (current (version-to-list current-string))
          (check (version-to-list version-string)))
-    (i (version-list-< current check)
+    (if (version-list-< current check)
       (user-error "This feature requires Syncthing version %s and %s is installed. Please upgrade Syncthing to use this feature."
                   version-string
                   current-string))))


### PR DESCRIPTION
This lets us ask Syncthing for which directories we should search for conflicts
in. This also alters the `emacs-conflict-resolve-conflicts` call to make the
directory optional. If not provided, all directories owned by Syncthing are
scanned.

Adds Syncthing conflict cache. Since searching large (i.e. multi-gigabyte)
directories can take a while, the results are cached for a speedier workflow. A
`emacs-conflict-syncthing-conflicts-refresh-cache` command is provided to
refresh the cache. When a conflict is resolved its entry in the cache is
cleared.

Adds a `emacs-conflict-remove-conflict` that lets the user interactively clear
conflicts if they're invalid or otherwise impractical to handle via this
package. Large binary files can be rejected by `ediff` and is cumbersome to work
with in Emacs anyways.

Simple management of the Syncthing API key is added - it's prompted for if it is
not set. Also, since it's very plausible that a user that would be interested in
this package is also syncing their dotfiles already, there's support for
multiple API keys (keyed on the result of `(system-name)`). This was discovered
to be a problem during development of these features, heh.

Finally, add a keymap with the interactive features bound. A suggested bind for
it could be `C-x c`, with the _conflict_ mnemonic.

---

This was written over two sessions a few months apart (started during the winter holidays, then finished it just now), but I hope it's still coherent. It seems to work nicely on my system here. 

Some things to consider when reviewing:

#### Add `dash` as a library
Just because some things are easier to express with it. It's only used in a few places, so it might be overkill. I know that some package maintainers are keen to keep dependencies to a minimum, so if that's the desired case here I can probably rewrite it to only use native Emacs functionality.

#### Some default behavior was altered
The call to `emacs-conflict-resolve-conflicts` is altered to default to using the Syncthing sources if no directory is specified. The previous behavior was to prompt for a directory, and that functionality is now shadowed away. There are probably ways to make it available again, but I boldly assumed that the Syncthing integration would be the desirable choice anyway. However, if a user does not want to (or is unable to) use a version of Syncthing that enables this functionality (at least `v.1.12.0`) that leaves them... worse. I can probably rework it to support that, but I didn't put time into that for now.

#### The version was bumped
This might be something for a different commit made by the maintainer, so I thought I should give a heads up about including that now.

---

I'm not the most experienced package contributor, but I hope this is a useful contribution! This was fun to write, and it was my first time using `ert` during development! :blush: 

Oh, and of course, thanks for a useful and well-made package!