### PR TITLE
Fix default find regexes

### DIFF
--- a/emacs-conflict.el
+++ b/emacs-conflict.el
@@ -58,7 +58,7 @@
   :prefix "emacs-conflict")
 
 (defcustom emacs-conflict-find-regexes
-  '(("syncthing" "\\.sync-conflict-.*\\(\\.?\\)" "\\1")
+  '(("syncthing" "\\.sync-conflict-[^.]*\\(\\.?\\)" "\\1")
     ("nextcloud" " (conflicted copy .*)\\(\\.?\\)" "\\1")
     ("pacman" "\\(?:\\.\\)pacnew$" ""))
   "Regexes to identify a file as a conflict."

--- a/emacs-conflict.el
+++ b/emacs-conflict.el
@@ -58,8 +58,8 @@
   :prefix "emacs-conflict")
 
 (defcustom emacs-conflict-find-regexes
-  '(("syncthing" "\\.sync-conflict-.*\\(\\.\\)" "\\1")
-    ("nextcloud" " (conflicted copy .*)\\(\\.\\)" "\\1")
+  '(("syncthing" "\\.sync-conflict-.*\\(\\.?\\)" "\\1")
+    ("nextcloud" " (conflicted copy .*)\\(\\.?\\)" "\\1")
     ("pacman" "\\(?:\\.\\)pacnew$" ""))
   "Regexes to identify a file as a conflict."
   :type '(alist :key-type string :value-type (list regexp regexp))


### PR DESCRIPTION
Fuck, sorry, I broke things yesterday with the Syncthing regex.`emacs-conflict--get-normal-filename` wouldn't return the file extension for files WITH an extension, but would work fine for files without.

This now works properly, I swear to God.